### PR TITLE
Changed the clobbers name to cordova.plugins.brightness.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,7 @@
 	</description>
 	
     <js-module src="www/brightness.js" name="Brightness">
-        <clobbers target="Brightness" />
+        <clobbers target="cordova.plugins.brightness" />
     </js-module>
     
 	<info>


### PR DESCRIPTION
Changed the clobbers name to "cordova.plugins.brightness" to be more in
line with the cordova plugins naming convention. This also prevents
this plugin from polluting the $window scope.
